### PR TITLE
Production update 1.8.2024

### DIFF
--- a/src/functions/purge-external-service-documents/index.ts
+++ b/src/functions/purge-external-service-documents/index.ts
@@ -4,6 +4,7 @@ import { AWSFunction } from "src/types";
 const fn: AWSFunction = {
   handler: `${handlerPath(__dirname)}/handler.main`,
   name: "elastic-app-functions-${opt:stage}-purgeExternalServiceDocs",
+  timeout: 900,
   events: [
     {
       schedule: {


### PR DESCRIPTION
Extended timeout of purgeExternalServiceDocs lambda, as it was left as default of 6 seconds, which is not nearly enough to actually purge anything.